### PR TITLE
#31 Add keyboard shortcuts for playback

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -498,6 +498,19 @@ $: if(player) {
 	mute = false;
 }
 
+var volumnUp = function() {
+	if(slider !== 100) {
+		slider = slider + 2;
+		player.volume(slider/100)
+	}
+}
+
+var volumnDown = function() {
+	if(slider !== 0) {
+		slider = slider - 2;
+		player.volume(slider/100)
+	}
+}
 var handleKeyboardPress = function (keycode) {
 	switch (keycode) {
 		case 'Space':

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -511,27 +511,50 @@ var volumnDown = function() {
 		player.volume(slider/100)
 	}
 }
+
 var handleKeyboardPress = function (keycode) {
 	switch (keycode) {
-		case 'Space':
+		//--Spacebar
+		case " ":
 			playMusic();
 			break;
-		case 'MediaPlayPause':
-			songPlaying = false;
+		case "MediaPlayPause":
+			songPlaying = !songPlaying;
 			break;
-		case 'MediaNextTrack':
+		case "MediaTrackNext":
 			nextSong();
 			break;
-		case 'MediaPreviousTrack':
+		case "MediaTrackPrevious":
 			prevSong();
+			break;
+		case "ArrowRight":
+			nextSong();
+			break;
+		case "ArrowLeft":
+			prevSong();
+			break;
+		case "ArrowUp":
+			volumnUp();
+			break;
+		case "ArrowDown":
+			volumnDown();
+			break;
+		case "AudioVolumeUp":
+			volumnUp();
+			break;
+		case "AudioVolumeDown":
+			volumnDown();
+			break;
+		case "AudioVolumeMute":
+			mute = !mute
 			break;
 		default:
 			break;
 	}
 }
 
-document.onkeypress = function (event) {
-    handleKeyboardPress(event.code)
+document.onkeydown = function (event) {
+    handleKeyboardPress(event.key)
 };
 
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -498,6 +498,29 @@ $: if(player) {
 	mute = false;
 }
 
+var handleKeyboardPress = function (keycode) {
+	switch (keycode) {
+		case 'Space':
+			playMusic();
+			break;
+		case 'MediaPlayPause':
+			songPlaying = false;
+			break;
+		case 'MediaNextTrack':
+			nextSong();
+			break;
+		case 'MediaPreviousTrack':
+			prevSong();
+			break;
+		default:
+			break;
+	}
+}
+
+document.onkeypress = function (event) {
+    handleKeyboardPress(event.code)
+};
+
 </script>
 
 <div class="container-fluid">


### PR DESCRIPTION
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Keypress listener added, supporting these following keys
1. Spacebar - Play/Pause
2. MediaPlayPause - Play/Pause
3. MediaTrackNext - Play Next Track
4. MediaTrackPrevious - Play Previous Track
5. ArrowRight - Play Next Track
6. ArrowLeft - Play Previous Track
7. ArrowUp - Volume Up
8. ArrowDown - Volume Down
9. AudioVolumeUp (tested with wheel-key) -  Volume Up
10. AudioVolumeDown (tested with wheel-key) - Volume Down
11. AudioVolumeMute - Mute

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
